### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,8 +78,10 @@ if len(sys.argv) < 1:
     else:
         print("Using token from main, do not git push this")
 else:
-    if len(sys.argv[1]) > 0:
+    #Sys.argv >=2
+    if len(sys.argv) == 2:
         TOKEN = sys.argv[1]
+    else:
         REPO_ID = sys.argv[2]
         REPO_NAME = sys.argv[3]
 


### PR DESCRIPTION
If you gave main it's REPO_ID and REPO_NAME directly in main, and it's token as an env key then the prev solution failed. This does not matter for github because there the user does not have option of giving REPO_ID and REPO_NAME as arguments. Basically, we added REPO_NAME = sys.argv[2] etc to the public version and this crashed in a bad way.